### PR TITLE
Added extension for egress

### DIFF
--- a/enkube/libsonnet/k.libsonnet
+++ b/enkube/libsonnet/k.libsonnet
@@ -172,6 +172,10 @@ Kubernetes object prototypes
         local i = if std.objectHas(s.spec, "ingress") then s.spec.ingress else [],
         ingress: i + [rule { from: rule.peers }],
       } },
+      egress(rule):: self + { spec+: {
+      local i = if std.objectHas(s.spec, "egress") then s.spec.egress else [],
+      egress: i + [rule { to: rule.peers }],
+      } },
     },
 
   NetworkPolicyRule(peers):: {


### PR DESCRIPTION
Creating PR to add an extension for k8s network policy in k.libsonnet. This will allow egress rules to be created.  This was originally implemented to create egress rules for the k8s vpn pods, but after further investigation, the logic doesn't seem to allow what's required.  The addition should be useful nonetheless. 