### PR TITLE
Fix imports and pip requirements

### DIFF
--- a/enkube/dump.py
+++ b/enkube/dump.py
@@ -15,7 +15,7 @@
 import click
 
 from .util import format_yaml, close_kernel
-from .api import ApiClient
+from .api.client import ApiClient
 from .main import pass_env
 
 

--- a/enkube/exec.py
+++ b/enkube/exec.py
@@ -18,7 +18,7 @@ import click
 
 from .util import flatten_kube_lists, format_json, close_kernel
 from .ctl import kubectl_popen
-from .api import ApiClient
+from .api.client import ApiClient
 from .main import pass_env
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ PyYAML
 asks
 click
 colorama
-curio
+curio==0.9
 deepdiff
 jinja2
 jsonnet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 PyYAML
-asks
+anyio==1.3.0
+asks==2.3.7
 click
 colorama
 curio==0.9
-deepdiff
+deepdiff==4.3.2
 jinja2
 jsonnet
 junit-xml


### PR DESCRIPTION
enkube was built against an older curio and is not compatible with versions >= 1.0.  Updated the requirements.txt to reflect this.  The import for ApiClient that was fixed 02c1b6ef249bb536665251c920e0e95cb8c62e42 also needed to be in dump.py and exec.py.  This includes that as well.